### PR TITLE
Follow FIPS 203, not FIPS 204

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ security parameter sets are fully functional. The implementation does not requir
 `#[no_std]`, has no heap allocations, e.g. no `alloc` needed, and exposes the `RNG` so it is suitable for the full range
 of applications down to the bare-metal. The API is stabilized and the code is heavily biased towards safety and
 correctness; further performance optimizations will be implemented as the standard matures. This crate will quickly
-follow any changes to FIPS 204 as they become available.
+follow any changes to FIPS 203 as they become available.
 
 See <https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.ipd.pdf> for a full description of the target functionality.
 


### PR DESCRIPTION
FIPS 204 is ML-DSA.  This crate implements FIPS 203 (ML-KEM), which is a different standard.